### PR TITLE
Falsche Potenz.

### DIFF
--- a/einfalg.tex
+++ b/einfalg.tex
@@ -2191,7 +2191,7 @@ Deshalb können wir $\IQ$ als Teilmenge von $K_p$ vermöge der (injektiven) Einb
 \begin{proof}
 	Wir wollen zeigen, dass
 	\begin{equation*}
-		B = \left\lbrace \ol{1}, \ol{t}, \ol{t}^2, \dots, \ol{t}^{p-1} \right\rbrace 
+		B = \left\lbrace \ol{1}, \ol{t}, \ol{t}^2, \dots, \ol{t}^{p-2} \right\rbrace 
 	\end{equation*}
 	eine Basis ist.
 	


### PR DESCRIPTION
Die Potenz sollte p-2 sein, und nicht p-1.